### PR TITLE
Migrate from FxCop analyzers to NETAnalyzers

### DIFF
--- a/src/oehen.arguard/oehen.arguard.csproj
+++ b/src/oehen.arguard/oehen.arguard.csproj
@@ -22,6 +22,10 @@
     <copyright>Copyright © oehen.net</copyright>
     <releaseNotes>https://github.com/eoehen/arguard/releases/</releaseNotes>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Remove="arguardlogo.png" />
@@ -33,7 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers'.

Add **AllEnabledByDefault**
Aggressive or opt-out mode, where all rules are enabled by default as build warnings. You can selectively opt out of individual rules to disable them.
