### PR TITLE
Add support for netstandard 2.0

### DIFF
--- a/src/oehen.arguard.Tests/oehen.arguard.Tests.csproj
+++ b/src/oehen.arguard.Tests/oehen.arguard.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -10,6 +9,10 @@
     <AssemblyName>oehen.arguard.Tests</AssemblyName>
 
     <LangVersion>8</LangVersion>
+
+    <OutputType>Library</OutputType>
+
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oehen.arguard/oehen.arguard.csproj
+++ b/src/oehen.arguard/oehen.arguard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <PackageId>oehen.arguard</PackageId>
     <NeutralLanguage>en-US</NeutralLanguage>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <RepositoryType>git</RepositoryType>
-    <LangVersion>8</LangVersion> 
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <!-- package properties -->


### PR DESCRIPTION
- Restore support for netstandard 2.0, if netstandard 2.1 doesn't support dotnet 4.7.2.